### PR TITLE
feature/new_pagination

### DIFF
--- a/backend/INtouch/settings.py
+++ b/backend/INtouch/settings.py
@@ -200,7 +200,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.BrowsableAPIRenderer",
     ],
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "api.pagination.CustomPagination",
     "PAGE_SIZE": DEFAULT_PAGE_SIZE,
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -106,6 +106,9 @@ class AssignmentClient(models.Model):
         null=True,
     )  # ссылка на задание, с которого назначено текущее
 
+    class Meta:
+        ordering = ["-add_date"]
+
 
 class Block(models.Model):
     question = models.CharField(max_length=250)
@@ -179,3 +182,6 @@ class DiaryNote(models.Model):
     clarifying_emotion = ArrayField(
         models.CharField(max_length=50, choices=CLARIFYING_EMOTIONS), blank=True
     )
+
+    class Meta:
+        ordering = ["-add_date"]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -125,6 +125,9 @@ class Block(models.Model):
         blank=True,
     )
 
+    class Meta:
+        ordering = ["-pk"]
+
 
 class BlockChoice(models.Model):
     reply = models.CharField(max_length=100)

--- a/backend/api/pagination.py
+++ b/backend/api/pagination.py
@@ -5,7 +5,7 @@ from rest_framework.pagination import PageNumberPagination
 
 
 class CustomPagination(PageNumberPagination):
-    page_size_query_param = "amount"
+    page_size_query_param = "limit"
 
     def get_paginated_response(self, data):
         return Response(

--- a/backend/api/pagination.py
+++ b/backend/api/pagination.py
@@ -1,0 +1,20 @@
+from collections import OrderedDict
+
+from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
+
+
+class CustomPagination(PageNumberPagination):
+    page_size_query_param = "amount"
+
+    def get_paginated_response(self, data):
+        return Response(
+            OrderedDict(
+                [
+                    ("items", self.page.paginator.count),
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
+                    ("results", data),
+                ]
+            )
+        )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -573,9 +573,10 @@ class AssignmentClientViewSet(
     ]
 
     def get_queryset(self):
-        if self.request.user.user_type == USER_TYPES[0]:
-            return self.request.user.client.assignments
-        return super().get_queryset()
+        user = self.request.user
+        if user.user_type == USER_TYPES[0]:
+            return user.client.assignments
+        return super().get_queryset().filter(visible=True)
 
     @action(detail=True, methods=["get"])
     def complete(self, request, pk):


### PR DESCRIPTION
Добавил постраничную пагинацию, дэфолт остался на 10 страницах, может меняться с помощью параметра `limit`, кол-во всех объектов теперь `items` вместо `amount`

Так получилось что закинул еще фикс на задания (чтобы доктору у клиентов было видно только задания с флагом `visible`), запрос пришел неожиданно + это 1 строчка кода, выносить это в отдельный пул не хотелось