### PR TITLE
fix: refresh token should refresh when expire

### DIFF
--- a/frontend/src/service/axios.jsx
+++ b/frontend/src/service/axios.jsx
@@ -27,7 +27,7 @@ function checkTokenExpiration(accessToken) {
     const decodedToken = JSON.parse(atob(accessToken.split('.')[1]));
     const currentTime = Math.floor(Date.now() / 1000);
     if (decodedToken.exp < currentTime) {
-      return false;
+      return !(decodedToken.exp < currentTime);
     }
     return true;
   } catch (error) {

--- a/frontend/src/service/axios.jsx
+++ b/frontend/src/service/axios.jsx
@@ -22,37 +22,55 @@ const processQueue = (error, token = null) => {
   failedRequestsQueue = [];
 };
 
+function checkTokenExpiration(accessToken) {
+  try {
+    const decodedToken = JSON.parse(atob(accessToken.split('.')[1]));
+    const currentTime = Math.floor(Date.now() / 1000);
+    if (decodedToken.exp < currentTime) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('Error decoding token:', error);
+    return false;
+  }
+}
+
 async function refreshTokens() {
   const refreshToken = localStorage.getItem('refreshToken');
   if (!refreshToken) {
     throw new Error('No refresh token available');
   }
-  try {
-    const response = await API.post('token/refresh/', { refresh: refreshToken });
-    const { access: newAccessToken, refresh: newRefreshToken } = response.data;
-    localStorage.setItem('accessToken', newAccessToken);
-    localStorage.setItem('refreshToken', newRefreshToken);
-    API.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
-    return newAccessToken;
-  } catch (error) {
-    console.error('Token refresh failed:', error);
-
-    localStorage.clear();
-    window.location.href = '/login'; // Redirect to login page on refresh failure
-    throw error; //Передаём ошибку дальше для обработки в интерцепторе ответов
+  // Проверяем, истек ли срок действия текущего токена
+  const accessToken = localStorage.getItem('accessToken');
+  if (checkTokenExpiration(accessToken)) {
+    return accessToken;
+  } else {
+    try {
+      const response = await API.post('token/refresh/', { refresh: refreshToken });
+      const { access: newAccessToken, refresh: newRefreshToken } = response.data;
+      localStorage.setItem('accessToken', newAccessToken);
+      localStorage.setItem('refreshToken', newRefreshToken);
+      API.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
+      return newAccessToken;
+    } catch (error) {
+      console.error('Token refresh failed:', error);
+      localStorage.clear();
+      window.location.href = '/login'; // Redirect to login page on refresh failure
+      throw error;
+    }
   }
 }
 
 API.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem('accessToken');
-    if (accessToken) {
+    if (accessToken && checkTokenExpiration(accessToken)) {
       config.headers['Authorization'] = `Bearer ${accessToken}`;
     }
     return config;
   },
   (error) => {
-    // return Promise.reject(error);
     throw error;
   },
 );
@@ -64,7 +82,7 @@ API.interceptors.response.use(
   async (error) => {
     console.error('Response error:', error);
     const originalRequest = error.config;
-    if (error.response.status === 401 && originalRequest._retry) {
+    if (error.response.status === 401) {
       try {
         const token = await refreshTokens();
         originalRequest.headers['Authorization'] = 'Bearer ' + token;


### PR DESCRIPTION
Добавлена функция проверки на то протух ли токен, в зависимости от этой функции запускается refreshToken, больше нет зависимости от error.config._retry.
Added a function to check whether the token is expired, depending on this function refreshToken is launched, there is no longer any dependence on error.config._retry.
https://int.kaiten.ru/space/287767/card/33481198?filter=eyJrZXkiOiJhbmQiLCJ2YWx1ZSI6W3sia2V5IjoiYW5kIiwidmFsdWUiOlt7ImNvbXBhcmlzb24iOiJlcSIsImtleSI6Im1lbWJlciIsInZhbHVlIjo1NzAzMTV9XX1dfQ