### PR TITLE
diary entry max length

### DIFF
--- a/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
@@ -9,7 +9,7 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil } from "../../../../utils/helperFunction/editorUtils";
 import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
@@ -30,14 +30,16 @@ export default function DiaryBlockAnalysisClient({
   );
 
   const handleBeforeInput = useCallback(
-    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
-    []
+    (chars, editorState) =>
+      handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    [],
   );
 
   const handlePastedText = useHandlePastedText(
     editorState,
     DIARY_MAX_LENGTH,
-    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "thoughts_analysis")
+    (newEditorState) =>
+      handleEditorStateChange(newEditorState, setValue, "thoughts_analysis"),
   );
 
   const block = getBlockConfig(getValues, "thoughts_analysis");

--- a/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import React, { useRef } from "react";
+import React, { useRef, useCallback } from "react";
 import "../DiaryPage.css";
 import { ToolbarProvider } from "../../../../service/ToolbarContext";
 import { EditorToolbar } from "../../../../service/editors-toolbar";
@@ -8,6 +8,8 @@ import useMobileWidth from "../../../../utils/hook/useMobileWidth";
 import { ClientDiary } from "../../../../utils/global-types";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
+import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
+import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
 
 interface Props {
   diary: ClientDiary;
@@ -24,6 +26,22 @@ export default function DiaryBlockAnalysisClient({
 
   const [editorState, handleEditorStateChange] = useEditorState(
     diary?.thoughts_analysis || null,
+  );
+
+  const handleBeforeInput = useCallback(
+    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    []
+  );
+
+  const handlePastedText = useCallback(
+    (pastedText, html, editorState) => handlePastedTextUtil(
+      pastedText,
+      html,
+      editorState,
+      DIARY_MAX_LENGTH,
+      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "thoughts_analysis")
+    ),
+    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
   );
 
   const block = getBlockConfig(getValues, "thoughts_analysis");
@@ -63,6 +81,8 @@ export default function DiaryBlockAnalysisClient({
               placeholder={"Write your answer here..."}
               block={block}
               isMobileWidth={isMobileWidth}
+              handleBeforeInput={handleBeforeInput}
+              handlePastedText={handlePastedText}
             />
           </ToolbarProvider>
         )}

--- a/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockAnalysisClient/DiaryBlockAnalysisClient.tsx
@@ -9,7 +9,8 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
   diary: ClientDiary;
@@ -33,15 +34,10 @@ export default function DiaryBlockAnalysisClient({
     []
   );
 
-  const handlePastedText = useCallback(
-    (pastedText, html, editorState) => handlePastedTextUtil(
-      pastedText,
-      html,
-      editorState,
-      DIARY_MAX_LENGTH,
-      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "thoughts_analysis")
-    ),
-    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  const handlePastedText = useHandlePastedText(
+    editorState,
+    DIARY_MAX_LENGTH,
+    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "thoughts_analysis")
   );
 
   const block = getBlockConfig(getValues, "thoughts_analysis");

--- a/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
@@ -55,14 +55,16 @@ export default function DiaryBlockEmotionClient({
   const value = getValues("emotion_type");
 
   const handleBeforeInput = useCallback(
-    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
-    []
+    (chars, editorState) =>
+      handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    [],
   );
 
   const handlePastedText = useHandlePastedText(
     editorState,
     DIARY_MAX_LENGTH,
-    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "emotion_type")
+    (newEditorState) =>
+      handleEditorStateChange(newEditorState, setValue, "emotion_type"),
   );
 
   return (

--- a/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 import "../DiaryPage.css";
 import {
   listEmotions,
@@ -14,6 +14,8 @@ import useMobileWidth from "../../../../utils/hook/useMobileWidth";
 import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
+import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
+import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
 
 interface Props {
   diary: ClientDiary;
@@ -51,6 +53,23 @@ export default function DiaryBlockEmotionClient({
 
   const value = getValues("emotion_type");
 
+  const handleBeforeInput = useCallback(
+    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    []
+  );
+
+  const handlePastedText = useCallback(
+    (pastedText, html, editorState) => handlePastedTextUtil(
+      pastedText,
+      html,
+      editorState,
+      DIARY_MAX_LENGTH,
+      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "emotion_type")
+    ),
+    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  );
+
+
   return (
     <>
       <div
@@ -83,6 +102,8 @@ export default function DiaryBlockEmotionClient({
                 placeholder={"Write your answer here..."}
                 block={block}
                 isMobileWidth={isMobileWidth}
+                handleBeforeInput={handleBeforeInput}
+                handlePastedText={handlePastedText}
               />
             </ToolbarProvider>
           )}

--- a/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockEmotionClient/DiaryBlockEmotionClient.tsx
@@ -15,7 +15,8 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil } from "../../../../utils/helperFunction/editorUtils";
+import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
   diary: ClientDiary;
@@ -58,17 +59,11 @@ export default function DiaryBlockEmotionClient({
     []
   );
 
-  const handlePastedText = useCallback(
-    (pastedText, html, editorState) => handlePastedTextUtil(
-      pastedText,
-      html,
-      editorState,
-      DIARY_MAX_LENGTH,
-      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "emotion_type")
-    ),
-    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  const handlePastedText = useHandlePastedText(
+    editorState,
+    DIARY_MAX_LENGTH,
+    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "emotion_type")
   );
-
 
   return (
     <>

--- a/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
@@ -10,7 +10,8 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
   diary: ClientDiary;
@@ -38,15 +39,10 @@ export default function DiaryBlockPhysicalSensationClient({
     []
   );
 
-  const handlePastedText = useCallback(
-    (pastedText, html, editorState) => handlePastedTextUtil(
-      pastedText,
-      html,
-      editorState,
-      DIARY_MAX_LENGTH,
-      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "physical_sensations")
-    ),
-    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  const handlePastedText = useHandlePastedText(
+    editorState,
+    DIARY_MAX_LENGTH,
+    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "physical_sensations")
   );
 
   return (

--- a/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
@@ -10,7 +10,7 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil } from "../../../../utils/helperFunction/editorUtils";
 import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
@@ -35,14 +35,16 @@ export default function DiaryBlockPhysicalSensationClient({
   const value = getValues("physical_sensations");
 
   const handleBeforeInput = useCallback(
-    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
-    []
+    (chars, editorState) =>
+      handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    [],
   );
 
   const handlePastedText = useHandlePastedText(
     editorState,
     DIARY_MAX_LENGTH,
-    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "physical_sensations")
+    (newEditorState) =>
+      handleEditorStateChange(newEditorState, setValue, "physical_sensations"),
   );
 
   return (

--- a/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
+++ b/frontend/src/components/client/DiaryPage/DiaryBlockPhysicalSensationClient/DiaryBlockPhysicalSensationClient.tsx
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import React, { useRef } from "react";
+import React, { useRef, useCallback } from "react";
 import "../DiaryPage.css";
 import { EditorState } from "draft-js";
 import { EditorToolbar } from "../../../../service/editors-toolbar";
@@ -9,6 +9,8 @@ import useMobileWidth from "../../../../utils/hook/useMobileWidth";
 import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
+import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
+import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
 
 interface Props {
   diary: ClientDiary;
@@ -30,6 +32,22 @@ export default function DiaryBlockPhysicalSensationClient({
   const block = getBlockConfig(getValues, "physical_sensations");
 
   const value = getValues("physical_sensations");
+
+  const handleBeforeInput = useCallback(
+    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    []
+  );
+
+  const handlePastedText = useCallback(
+    (pastedText, html, editorState) => handlePastedTextUtil(
+      pastedText,
+      html,
+      editorState,
+      DIARY_MAX_LENGTH,
+      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "physical_sensations")
+    ),
+    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  );
 
   return (
     <div
@@ -63,6 +81,8 @@ export default function DiaryBlockPhysicalSensationClient({
               placeholder={"Write your answer here..."}
               block={block}
               isMobileWidth={isMobileWidth}
+              handleBeforeInput={handleBeforeInput}
+              handlePastedText={handlePastedText}
             />
           </ToolbarProvider>
         )}

--- a/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
+++ b/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
@@ -9,7 +9,8 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
   diary: ClientDiary;
@@ -38,15 +39,11 @@ export default function EventDetailsClient({
     []
   );
 
-  const handlePastedText = useCallback(
-    (pastedText, html, editorState) => handlePastedTextUtil(
-      pastedText,
-      html,
-      editorState,
-      DIARY_MAX_LENGTH,
-      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "event_details")
-    ),
-    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+
+  const handlePastedText = useHandlePastedText(
+    editorState,
+    DIARY_MAX_LENGTH,
+    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "event_details")
   );
 
   return (

--- a/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
+++ b/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import "../DiaryPage.css";
 import { ToolbarProvider } from "../../../../service/ToolbarContext";
 import { EditorToolbar } from "../../../../service/editors-toolbar";
@@ -8,6 +8,8 @@ import useMobileWidth from "../../../../utils/hook/useMobileWidth";
 import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
+import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
+import { handleBeforeInput as handleBeforeInputUtil, handlePastedText as handlePastedTextUtil } from "../../../../utils/helperFunction/editorUtils";
 
 interface Props {
   diary: ClientDiary;
@@ -30,6 +32,22 @@ export default function EventDetailsClient({
   const block = getBlockConfig(getValues, "event_details");
 
   const value = getValues("event_details");
+
+  const handleBeforeInput = useCallback(
+    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    []
+  );
+
+  const handlePastedText = useCallback(
+    (pastedText, html, editorState) => handlePastedTextUtil(
+      pastedText,
+      html,
+      editorState,
+      DIARY_MAX_LENGTH,
+      (newEditorState) => handleEditorStateChange(newEditorState, setValue, "event_details")
+    ),
+    [DIARY_MAX_LENGTH, handleEditorStateChange, setValue]
+  );
 
   return (
     <div
@@ -63,6 +81,8 @@ export default function EventDetailsClient({
               placeholder={"Write your answer here..."}
               block={block}
               isMobileWidth={isMobileWidth}
+              handleBeforeInput={handleBeforeInput}
+              handlePastedText={handlePastedText}
             />
           </ToolbarProvider>
         )}

--- a/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
+++ b/frontend/src/components/client/DiaryPage/EventDetailsClient/EventDetailsClient.tsx
@@ -9,7 +9,7 @@ import { ClientDiary } from "../../../../utils/global-types";
 import { useEditorState } from "../../../../utils/hook/useEditorState";
 import { getBlockConfig } from "../../../../utils/helperFunction/getBlockConfig";
 import { DIARY_MAX_LENGTH } from "../../../../utils/constants";
-import { handleBeforeInput as handleBeforeInputUtil} from "../../../../utils/helperFunction/editorUtils";
+import { handleBeforeInput as handleBeforeInputUtil } from "../../../../utils/helperFunction/editorUtils";
 import useHandlePastedText from "../../../../utils/hook/useHandlePastedText";
 
 interface Props {
@@ -35,15 +35,16 @@ export default function EventDetailsClient({
   const value = getValues("event_details");
 
   const handleBeforeInput = useCallback(
-    (chars, editorState) => handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
-    []
+    (chars, editorState) =>
+      handleBeforeInputUtil(chars, editorState, DIARY_MAX_LENGTH),
+    [],
   );
-
 
   const handlePastedText = useHandlePastedText(
     editorState,
     DIARY_MAX_LENGTH,
-    (newEditorState) => handleEditorStateChange(newEditorState, setValue, "event_details")
+    (newEditorState) =>
+      handleEditorStateChange(newEditorState, setValue, "event_details"),
   );
 
   return (

--- a/frontend/src/routes/AssignmentsPageRefactor/ModalsAssignments/ModalAssignments.tsx
+++ b/frontend/src/routes/AssignmentsPageRefactor/ModalsAssignments/ModalAssignments.tsx
@@ -50,7 +50,7 @@ export default function ModalAssignments({
       }
 
       const { payload }: any = await dispatch(
-        setClientByIdAction({ assignmentId, selectedClients })
+        setClientByIdAction({ assignmentId, selectedClients }),
       );
 
       const allResponsesSuccessful =

--- a/frontend/src/service/forms/set-new-user-password.tsx
+++ b/frontend/src/service/forms/set-new-user-password.tsx
@@ -52,7 +52,7 @@ function SetNewUserPassword({ accessToken }) {
     setIsValidCredentials(!newError.password && password === confirmPassword);
 
     // Возвращаем true, если ошибок нет, иначе false
-    return !newError.password
+    return !newError.password;
   };
 
   const handleSubmit = async (e) => {
@@ -60,7 +60,6 @@ function SetNewUserPassword({ accessToken }) {
     setError({ password: "", server: "" });
 
     const isValid = validatePassword();
-
 
     if (isValid) {
       try {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -76,3 +76,5 @@ export enum BlockType {
   Image = "image",
   Open = "open",
 }
+
+export const DIARY_MAX_LENGTH = 1000;

--- a/frontend/src/utils/helperFunction/editorUtils.ts
+++ b/frontend/src/utils/helperFunction/editorUtils.ts
@@ -1,0 +1,45 @@
+import { EditorState, Modifier } from "draft-js";
+
+// Disables further typing if max length is reached
+export const handleBeforeInput = (chars: string, editorState: EditorState, maxLength: number) => {
+  const currentContent = editorState.getCurrentContent();
+  const currentText = currentContent.getPlainText();
+
+  if (currentText.length >= maxLength) {
+    return "handled";
+  }
+  return "not-handled";
+};
+
+// Crops pasted string if longer than max length
+export const handlePastedText = (
+  pastedText: string,
+  html: string | undefined,
+  editorState: EditorState,
+  maxLength: number,
+  handleEditorStateChange: (newEditorState: EditorState) => void
+) => {
+  const currentContent = editorState.getCurrentContent();
+  const currentText = currentContent.getPlainText();
+
+  if (currentText.length + pastedText.length > maxLength) {
+    const maxLengthAllowed = maxLength - currentText.length;
+    const truncatedText = pastedText.slice(0, maxLengthAllowed);
+
+    const contentStateWithPastedText = Modifier.insertText(
+      currentContent,
+      editorState.getSelection(),
+      truncatedText
+    );
+
+    const newEditorState = EditorState.push(
+      editorState,
+      contentStateWithPastedText,
+      'insert-characters'
+    );
+    handleEditorStateChange(newEditorState);
+    return 'handled';
+  }
+
+  return 'not-handled';
+};

--- a/frontend/src/utils/helperFunction/editorUtils.ts
+++ b/frontend/src/utils/helperFunction/editorUtils.ts
@@ -10,36 +10,3 @@ export const handleBeforeInput = (chars: string, editorState: EditorState, maxLe
   }
   return "not-handled";
 };
-
-// Crops pasted string if longer than max length
-export const handlePastedText = (
-  pastedText: string,
-  html: string | undefined,
-  editorState: EditorState,
-  maxLength: number,
-  handleEditorStateChange: (newEditorState: EditorState) => void
-) => {
-  const currentContent = editorState.getCurrentContent();
-  const currentText = currentContent.getPlainText();
-
-  if (currentText.length + pastedText.length > maxLength) {
-    const maxLengthAllowed = maxLength - currentText.length;
-    const truncatedText = pastedText.slice(0, maxLengthAllowed);
-
-    const contentStateWithPastedText = Modifier.insertText(
-      currentContent,
-      editorState.getSelection(),
-      truncatedText
-    );
-
-    const newEditorState = EditorState.push(
-      editorState,
-      contentStateWithPastedText,
-      'insert-characters'
-    );
-    handleEditorStateChange(newEditorState);
-    return 'handled';
-  }
-
-  return 'not-handled';
-};

--- a/frontend/src/utils/helperFunction/editorUtils.ts
+++ b/frontend/src/utils/helperFunction/editorUtils.ts
@@ -1,7 +1,11 @@
 import { EditorState } from "draft-js";
 
 // Disables further typing if max length is reached
-export const handleBeforeInput = (chars: string, editorState: EditorState, maxLength: number) => {
+export const handleBeforeInput = (
+  chars: string,
+  editorState: EditorState,
+  maxLength: number,
+) => {
   const currentContent = editorState.getCurrentContent();
   const currentText = currentContent.getPlainText();
 

--- a/frontend/src/utils/helperFunction/editorUtils.ts
+++ b/frontend/src/utils/helperFunction/editorUtils.ts
@@ -1,4 +1,4 @@
-import { EditorState, Modifier } from "draft-js";
+import { EditorState } from "draft-js";
 
 // Disables further typing if max length is reached
 export const handleBeforeInput = (chars: string, editorState: EditorState, maxLength: number) => {

--- a/frontend/src/utils/hook/useHandlePastedText.ts
+++ b/frontend/src/utils/hook/useHandlePastedText.ts
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+import { EditorState, Modifier } from "draft-js";
+
+const useHandlePastedText = (
+  editorState: EditorState,
+  maxLength: number,
+  handleEditorStateChange: (newEditorState: EditorState) => void
+) => {
+  return useCallback(
+    (pastedText: string, html: string | undefined) => {
+      const currentContent = editorState.getCurrentContent();
+      const currentText = currentContent.getPlainText();
+
+      if (currentText.length + pastedText.length > maxLength) {
+        const maxLengthAllowed = maxLength - currentText.length;
+        const truncatedText = pastedText.slice(0, maxLengthAllowed);
+
+        const contentStateWithPastedText = Modifier.insertText(
+          currentContent,
+          editorState.getSelection(),
+          truncatedText
+        );
+
+        const newEditorState = EditorState.push(
+          editorState,
+          contentStateWithPastedText,
+          "insert-characters"
+        );
+        handleEditorStateChange(newEditorState);
+        return "handled";
+      }
+
+      return "not-handled";
+    },
+    [editorState, maxLength, handleEditorStateChange]
+  );
+};
+
+export default useHandlePastedText;

--- a/frontend/src/utils/hook/useHandlePastedText.ts
+++ b/frontend/src/utils/hook/useHandlePastedText.ts
@@ -4,7 +4,7 @@ import { EditorState, Modifier } from "draft-js";
 const useHandlePastedText = (
   editorState: EditorState,
   maxLength: number,
-  handleEditorStateChange: (newEditorState: EditorState) => void
+  handleEditorStateChange: (newEditorState: EditorState) => void,
 ) => {
   return useCallback(
     (pastedText: string, html: string | undefined) => {
@@ -18,13 +18,13 @@ const useHandlePastedText = (
         const contentStateWithPastedText = Modifier.insertText(
           currentContent,
           editorState.getSelection(),
-          truncatedText
+          truncatedText,
         );
 
         const newEditorState = EditorState.push(
           editorState,
           contentStateWithPastedText,
-          "insert-characters"
+          "insert-characters",
         );
         handleEditorStateChange(newEditorState);
         return "handled";
@@ -32,7 +32,7 @@ const useHandlePastedText = (
 
       return "not-handled";
     },
-    [editorState, maxLength, handleEditorStateChange]
+    [editorState, maxLength, handleEditorStateChange],
   );
 };
 


### PR DESCRIPTION
Клиент имеет возможность заполнить только до 1000 символов в дневнике. Более 1000 не даем вводить. Также если вставляет в поле текст более 1000 символов - обрезаем до нужной длины.