### PR TITLE
deleted placeholder text for psy

### DIFF
--- a/frontend/src/utils/helperFunction/parseEventDetailsText.ts
+++ b/frontend/src/utils/helperFunction/parseEventDetailsText.ts
@@ -1,6 +1,6 @@
 import { convertFromRaw, ContentState } from "draft-js";
 
-const DEFAULT_MESSAGE = "Write your answer here...";
+const DEFAULT_MESSAGE = "";
 
 export const parseEventDetailsText = (details: string): string => {
   if (typeof details !== "string") {


### PR DESCRIPTION
Если клиент не заполнил поле дневника, в ЛК психолога отображается пустой блок вместо текста плейсхолдера 