### PR TITLE
fixed displaying change password alerts

### DIFF
--- a/frontend/src/routes/SettingPage/SecurityTab/SeciurityTab.tsx
+++ b/frontend/src/routes/SettingPage/SecurityTab/SeciurityTab.tsx
@@ -20,6 +20,8 @@ export const SecurityTab = () => {
   });
   const [message, setMessage] = useState("");
   const [showModal, setShowModal] = useState(false);
+  const [showSuccessAlert, setShowSuccessAlert] = useState(false);
+  const [showErrorAlert, setShowErrorAlert] = useState(false);
   const { logout } = useAuth();
   const navigate = useNavigate();
 
@@ -40,11 +42,21 @@ export const SecurityTab = () => {
 
     try {
       const response = await API.post(`user/update/password/`, userPassword);
-      console.log(response.data);
       setMessage(response.data.message);
+      setShowSuccessAlert(true);
+
+      setTimeout(() => {
+        setShowSuccessAlert(false);
+      }, 2000);
+
     } catch (e) {
-      console.error(e);
-      setMessage("Error updating password: " + e.data?.message);
+      console.error("response.data.message", e.response.data.new_password);
+      setMessage("Error updating password: " + e.response.data.new_password.join(' '));
+      setShowErrorAlert(true);
+
+      setTimeout(() => {
+        setShowErrorAlert(false);
+      }, 2000);
     }
   };
 
@@ -134,7 +146,8 @@ export const SecurityTab = () => {
               type="submit"
             />
           </form>
-          {message && <div className="success-message">{message}</div>}
+          {showSuccessAlert && message && <div className="success-message">{message}</div>}
+          {showErrorAlert && message && <div className="error-message">{message}</div>}
         </div>
       </div>
       <div className="danger-zone">


### PR DESCRIPTION
в ЛК в настройках (и психолога, и клиента) при попытке сменить пароль не отображались нужные алерты (зеленый если успех, красный если ошибка) и не отображалась причина ошибки 